### PR TITLE
Validate body keys for /address endpoint

### DIFF
--- a/backend/src/addresses.ts
+++ b/backend/src/addresses.ts
@@ -35,6 +35,13 @@ export function initAddressEndpoints(server: express.Application): void {
         });
     });
     server.post("/address", (req, res) => {
+        const { email, address } = req.body;
+        if (!email) {
+            return res.status(400).json({ code: 400, message: "No email supplied " });
+        }
+        if (!address) {
+            return res.status(400).json({ code: 400, message: "No address to add supplied " });
+        }
         addAddress(req.body.email, req.body.address, (resp) => {
             res.status(resp.code).json(resp);
         });


### PR DESCRIPTION
Validates the `email` and `address` keys of the request body when processing the `POST /address` endpoint before calling the implementation function, `addAddress`. Hopefully this extra runtime checking will save potential headaches.