### PR TITLE
Update API with usage of helper.js functions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,11 +1,11 @@
 # Back-end API
 
+> If you're on VS Code, you can open the rendered version of this page with `Ctrl+Shift+V`.
+
 - [Back-end API](#back-end-api)
   - [Running the Server](#running-the-server)
   - [Using the Endpoint API](#using-the-endpoint-api)
   - [`fetch()` API Crash Quick Start](#fetch-api-crash-quick-start)
-    - [POST Request Boilerplate](#post-request-boilerplate)
-    - [GET Request Boilerplate](#get-request-boilerplate)
   - [Authentication API](#authentication-api)
     - [POST `/create-user`](#post-create-user)
     - [POST `/login-user`](#post-login-user)
@@ -18,8 +18,6 @@
     - [GET `/all-sent-emails`](#get-all-sent-emails)
     - [GET `/all-received-emails`](#get-all-received-emails)
     - [POST `/email`](#post-email)
-  - [User API](#user-api)
-  - [Search API](#search-api)
 
 
 
@@ -33,7 +31,19 @@ npx tsc
 npm start
 ```
 
-As long as this shell is running, the server is live and listening for requests. You can then run your front-end React app like you normally would, in a separate shell instance:
+This automatically updates any dependencies and starts the server runtime.
+
+**While the server is running,** you can populate your local database file with some dummy data with another shell:
+
+```powershell
+cd backend
+npm run populate  # clear all tables and insert dummy data
+npm run clear     # or just clear all tables
+```
+
+As long as the back-end shell is running, the server is live and listening for requests, and you can run `npm run populate` as many times as you want to reset the database back to its original dummy data.
+
+You can then run your front-end React app like you normally would, in a separate shell instance:
 
 ```powershell
 cd frontend
@@ -42,8 +52,6 @@ npm start
 
 
 ## Using the Endpoint API
-
-> If you're on VS Code, you can open the rendered version of this page with `Ctrl+Shift+V`.
 
 **ENDPOINT BASE URL:** `http://localhost:80`
 
@@ -62,84 +70,41 @@ Some good resources:
 * [Mozilla fetch() API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
 
 
-### POST Request Boilerplate
-
-You can supply the required metadata as part of the `init` parameter object to `fetch()`:
+**UPDATE:** I added the helper functions `getFromServer` and `postToServer` in a [helper.js module](../frontend/src/helper.js) to extract the `fetch()` API.
 
 ```javascript
-/* POST REQUEST BOILERPLATE */
-
-fetch('http://localhost:80/create-user', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-        email: 'josie_bruin@ucla.edu',
-        pw: '12345678'
-    })
-})
-    // Convert the Response object to JSON
-    .then(response => response.json())
-    // Code to run using that JSON data
-    .then(data => useThisData(data))
-    // Code to run if fetching failed
-    .catch(console.error);
+import { getFromServer, postToServer } from "./path/to/helper";
 ```
 
-In the above example, the **request body**:
+Some examples from within a class-based React component:
 
 ```javascript
-{
-    email: 'josie_bruin@ucla.edu',
-    pw: '12345678'
-}
+getFromServer("/all-addresses", {  // endpoint name
+  email: "josie_bruin@ucla.edu"    // parameters to supply
+},
+  // callback that uses the JSON response data
+  data => this.setState({ addresses: data.addresses })
+);
 ```
-
-Is what you're *sending* to the endpoint `http://localhost:80/create-user`. The **JSON response** is captured in the second `.then()`, as the `data` parameter. Usually you would pass this newly received data into the state of your current component for further processing. This allows you to act on this data on your own terms instead of being confined to this callback hell.
 
 ```javascript
-/* other code */
-    .then((data) => {
-        this.setState({
-            foo: data.burger,
-            bar: data.sandwich * 2 // or whatever
-        })
-    })
-/* other code */
-
-// Then maybe some other part of your component class is responsible
-// for doing something with this.state.foo and this.state.bar.
+postToServer("/address", {          // endpoint name
+  email: "josie_bruin@ucla.edu",    // JSON body to supply
+  address: "my_throwaway@2me.com",
+},
+  // callback that uses the JSON response data
+  data => {
+    if (data.code === 400) {
+      alert(data.message);  // '<address> already taken!'
+      /* failure code */
+    } else {
+      /* success code */
+    }
+  }
+);
 ```
 
-Another advantage of this is that `this.setState()` tells React to re-render the component, allowing whatever change you just made to take effect *visually*.
-
-
-### GET Request Boilerplate
-
-It's a bit simpler for **GET** requests:
-
-```javascript
-/* GET REQUEST BOILERPLATE */
-
-const params = new URLSearchParams({
-    address: 'josie_bruin@ucla.edu',
-}).toString();
-fetch(`http://localhost:80/all-addresses?${params}`)
-    .then(response => response.json())
-    .then(data => useThisData(data))
-    .catch(console.error);
-```
-
-In the above example, the key-value pair:
-
-```javascript
-{
-    address: 'josie_bruin@ucla.edu'
-}
-```
-
-Is converted into a URL-encoded string `email=josie_bruin@ucla.edu`, which is now safe to append to the endpoint after the special `?` token, denoting **URL parameters**. Don't forget the `?` between `http://localhost:80` and your parameters string!
-
-[As with above](#post-request-boilerplate), typically you'd want to call React's `this.setState()` with the data you just received so that you can process it outside of the callback, also telling React to re-render the component.
+Because of the nature of asynchronous code, you'll most likely be taking the response data from the endpoint and calling `this.setState` with it to be processed in some other part of the component, like `render()`. The advantage of this is that `this.setState` automatically tells React to re-render the component, making whatever change you just made to take effect *visually*.
 
 The rest of the sections are the documentation for the specific endpoints. They're designed so that you can simply replace the respective `body` or `params` boilerplate in the request with the objects show in each example. Processing the JSON response, `data`, is then a matter of knowing what keys are available and what types they are, which are also provided in examples below.
 
@@ -399,13 +364,3 @@ Example response JSON:
   "message": "Stored email from throwaway2@lmao.com to eggert@cs.ucla.edu,throwaway4@lmao.com"
 }
 ```
-
-
-## User API
-
-TODO?
-
-
-## Search API
-
-TODO?


### PR DESCRIPTION
Update the documentation to include usage examples of the `helper.js` helper functions I wrote to abstract the nasty `fetch()` API used to make requests to back-end endpoints. I also showed @abigailokonski how to use these in combination with React's `this.setState()`, so ask her or look at her existing examples if anyone's confused.